### PR TITLE
✨ feat: MongoDB 채팅 히스토리 및 금융 캘린더 기능 추가

### DIFF
--- a/BE/HanaZoom/build.gradle
+++ b/BE/HanaZoom/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 	// redis client
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	// mongodb
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
 	// json library
 	implementation 'org.json:json:20240303'
 

--- a/BE/HanaZoom/src/main/java/com/hanazoom/domain/chat/controller/ChatController.java
+++ b/BE/HanaZoom/src/main/java/com/hanazoom/domain/chat/controller/ChatController.java
@@ -3,11 +3,15 @@ package com.hanazoom.domain.chat.controller;
 import com.hanazoom.global.dto.ApiResponse;
 import com.hanazoom.domain.member.service.MemberService;
 import com.hanazoom.domain.region.service.RegionService;
+import com.hanazoom.domain.chat.service.RegionChatService;
+import com.hanazoom.domain.chat.document.RegionChatMessage;
 import com.hanazoom.global.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -17,6 +21,7 @@ public class ChatController {
 
     private final MemberService memberService;
     private final RegionService regionService;
+    private final RegionChatService regionChatService;
     private final JwtUtil jwtUtil;
 
     @GetMapping("/region-info")
@@ -46,6 +51,74 @@ public class ChatController {
         } catch (Exception e) {
             log.error("지역 정보 조회 중 오류 발생", e);
             return ResponseEntity.badRequest().body(ApiResponse.error("지역 정보를 가져올 수 없습니다: " + e.getMessage()));
+        }
+    }
+
+    /**
+     * 특정 지역의 이전 채팅 메시지를 조회합니다.
+     *
+     * @param regionId 지역 ID
+     * @param page     페이지 번호 (기본값: 0)
+     * @param size     페이지 크기 (기본값: 50)
+     * @return 이전 채팅 메시지 목록
+     */
+    @GetMapping("/region/{regionId}/messages")
+    public ResponseEntity<ApiResponse<List<RegionChatMessage>>> getRegionMessages(
+            @PathVariable Long regionId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "50") int size) {
+        try {
+            log.info("📥 지역 채팅 메시지 조회 요청: regionId={}, page={}, size={}", regionId, page, size);
+
+            List<RegionChatMessage> messages = regionChatService.getRecentMessages(regionId, page, size);
+
+            return ResponseEntity.ok(ApiResponse.success(messages));
+        } catch (Exception e) {
+            log.error("❌ 지역 채팅 메시지 조회 중 오류 발생", e);
+            return ResponseEntity.badRequest().body(
+                    ApiResponse.error("채팅 메시지를 가져올 수 없습니다: " + e.getMessage()));
+        }
+    }
+
+    /**
+     * 특정 지역의 최근 N개 메시지를 조회합니다.
+     *
+     * @param regionId 지역 ID
+     * @param limit    조회할 메시지 개수 (기본값: 50)
+     * @return 최근 채팅 메시지 목록
+     */
+    @GetMapping("/region/{regionId}/recent")
+    public ResponseEntity<ApiResponse<List<RegionChatMessage>>> getRecentMessages(
+            @PathVariable Long regionId,
+            @RequestParam(defaultValue = "50") int limit) {
+        try {
+            log.info("📥 지역 최근 채팅 메시지 조회 요청: regionId={}, limit={}", regionId, limit);
+
+            List<RegionChatMessage> messages = regionChatService.getRecentMessages(regionId, limit);
+
+            return ResponseEntity.ok(ApiResponse.success(messages));
+        } catch (Exception e) {
+            log.error("❌ 최근 채팅 메시지 조회 중 오류 발생", e);
+            return ResponseEntity.badRequest().body(
+                    ApiResponse.error("최근 채팅 메시지를 가져올 수 없습니다: " + e.getMessage()));
+        }
+    }
+
+    /**
+     * 특정 지역의 총 메시지 개수를 조회합니다.
+     *
+     * @param regionId 지역 ID
+     * @return 메시지 개수
+     */
+    @GetMapping("/region/{regionId}/count")
+    public ResponseEntity<ApiResponse<Long>> getMessageCount(@PathVariable Long regionId) {
+        try {
+            Long count = regionChatService.getMessageCount(regionId);
+            return ResponseEntity.ok(ApiResponse.success(count));
+        } catch (Exception e) {
+            log.error("❌ 메시지 개수 조회 중 오류 발생", e);
+            return ResponseEntity.badRequest().body(
+                    ApiResponse.error("메시지 개수를 가져올 수 없습니다: " + e.getMessage()));
         }
     }
 

--- a/BE/HanaZoom/src/main/java/com/hanazoom/domain/chat/document/RegionChatMessage.java
+++ b/BE/HanaZoom/src/main/java/com/hanazoom/domain/chat/document/RegionChatMessage.java
@@ -1,0 +1,55 @@
+package com.hanazoom.domain.chat.document;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Document(collection = "region_chat_messages")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RegionChatMessage {
+
+    @Id
+    private String id; // MongoDB의 ObjectId를 사용하지 않고 UUID 문자열 사용
+
+    @Field("region_id")
+    @Indexed
+    private Long regionId;
+
+    @Field("member_id")
+    @Indexed
+    private String memberId; // UUID를 문자열로 저장
+
+    @Field("member_name")
+    private String memberName;
+
+    @Field("content")
+    private String content;
+
+    @Field("message_type")
+    private String messageType; // CHAT, ENTER, LEAVE, SYSTEM, WELCOME
+
+    @Field("created_at")
+    private LocalDateTime createdAt;
+
+    @Field("images")
+    private List<String> images; // Base64 이미지 또는 이미지 URL
+
+    @Field("image_count")
+    private Integer imageCount;
+
+    @Field("portfolio_stocks")
+    private List<Map<String, Object>> portfolioStocks; // 보유종목 정보
+}

--- a/BE/HanaZoom/src/main/java/com/hanazoom/domain/chat/repository/RegionChatMessageRepository.java
+++ b/BE/HanaZoom/src/main/java/com/hanazoom/domain/chat/repository/RegionChatMessageRepository.java
@@ -1,0 +1,39 @@
+package com.hanazoom.domain.chat.repository;
+
+import com.hanazoom.domain.chat.document.RegionChatMessage;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface RegionChatMessageRepository extends MongoRepository<RegionChatMessage, String> {
+
+    /**
+     * 특정 지역의 최신 메시지 조회 (페이징)
+     * 
+     * @param regionId 지역 ID
+     * @param pageable 페이징 정보
+     * @return 메시지 페이지
+     */
+    Page<RegionChatMessage> findByRegionIdOrderByCreatedAtDesc(Long regionId, Pageable pageable);
+
+    /**
+     * 특정 지역의 최근 N개 메시지 조회
+     * 
+     * @param regionId 지역 ID
+     * @return 메시지 목록 (최신순)
+     */
+    List<RegionChatMessage> findTop100ByRegionIdOrderByCreatedAtDesc(Long regionId);
+
+    /**
+     * 특정 지역의 메시지 개수 조회
+     * 
+     * @param regionId 지역 ID
+     * @return 메시지 개수
+     */
+    Long countByRegionId(Long regionId);
+}
+

--- a/BE/HanaZoom/src/main/java/com/hanazoom/domain/chat/service/RegionChatService.java
+++ b/BE/HanaZoom/src/main/java/com/hanazoom/domain/chat/service/RegionChatService.java
@@ -1,0 +1,154 @@
+package com.hanazoom.domain.chat.service;
+
+import com.hanazoom.domain.chat.document.RegionChatMessage;
+import com.hanazoom.domain.chat.repository.RegionChatMessageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RegionChatService {
+
+    private final RegionChatMessageRepository chatMessageRepository;
+
+    /**
+     * 채팅 메시지를 MongoDB에 저장합니다.
+     * ENTER, LEAVE, SYSTEM, WELCOME 메시지는 저장하지 않습니다.
+     *
+     * @param messageId       메시지 ID (UUID)
+     * @param regionId        지역 ID
+     * @param memberId        회원 ID (UUID)
+     * @param memberName      회원 이름
+     * @param content         메시지 내용
+     * @param messageType     메시지 타입
+     * @param images          이미지 리스트
+     * @param imageCount      이미지 개수
+     * @param portfolioStocks 보유종목 정보
+     */
+    public void saveChatMessage(
+            String messageId,
+            Long regionId,
+            String memberId,
+            String memberName,
+            String content,
+            String messageType,
+            List<String> images,
+            Integer imageCount,
+            List<Map<String, Object>> portfolioStocks) {
+        try {
+            // ENTER, LEAVE, SYSTEM, WELCOME 메시지는 저장하지 않음 (임시 메시지)
+            if ("ENTER".equals(messageType) || "LEAVE".equals(messageType) ||
+                    "SYSTEM".equals(messageType) || "WELCOME".equals(messageType)) {
+                return;
+            }
+
+            RegionChatMessage message = RegionChatMessage.builder()
+                    .id(messageId)
+                    .regionId(regionId)
+                    .memberId(memberId)
+                    .memberName(memberName)
+                    .content(content)
+                    .messageType(messageType)
+                    .createdAt(LocalDateTime.now())
+                    .images(images)
+                    .imageCount(imageCount)
+                    .portfolioStocks(portfolioStocks)
+                    .build();
+
+            chatMessageRepository.save(message);
+            log.debug("💾 채팅 메시지 저장 완료: regionId={}, messageId={}, memberName={}",
+                    regionId, messageId, memberName);
+
+        } catch (Exception e) {
+            log.error("❌ 채팅 메시지 저장 실패: regionId={}, messageId={}", regionId, messageId, e);
+            // 메시지 저장 실패는 채팅 기능에 영향을 주지 않도록 예외를 무시합니다.
+        }
+    }
+
+    /**
+     * 특정 지역의 이전 채팅 메시지를 조회합니다.
+     *
+     * @param regionId 지역 ID
+     * @param page     페이지 번호 (0부터 시작)
+     * @param size     페이지 크기
+     * @return 메시지 목록 (오래된 순으로 정렬)
+     */
+    public List<RegionChatMessage> getRecentMessages(Long regionId, int page, int size) {
+        try {
+            // 최신 메시지부터 조회한 후, 클라이언트에서 역순으로 표시
+            Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+            Page<RegionChatMessage> messagePage = chatMessageRepository.findByRegionIdOrderByCreatedAtDesc(regionId,
+                    pageable);
+
+            // 메시지를 오래된 순으로 뒤집어서 반환 (채팅창에서는 오래된 메시지가 위에 표시)
+            List<RegionChatMessage> messages = messagePage.getContent();
+            Collections.reverse(messages);
+
+            log.info("📥 채팅 메시지 조회 완료: regionId={}, page={}, size={}, totalMessages={}",
+                    regionId, page, size, messages.size());
+
+            return messages;
+
+        } catch (Exception e) {
+            log.error("❌ 채팅 메시지 조회 실패: regionId={}", regionId, e);
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * 특정 지역의 최근 N개 메시지를 조회합니다.
+     *
+     * @param regionId 지역 ID
+     * @param limit    조회할 메시지 개수
+     * @return 메시지 목록 (오래된 순으로 정렬)
+     */
+    public List<RegionChatMessage> getRecentMessages(Long regionId, int limit) {
+        try {
+            List<RegionChatMessage> messages = chatMessageRepository.findTop100ByRegionIdOrderByCreatedAtDesc(regionId);
+
+            // limit 적용
+            if (messages.size() > limit) {
+                messages = messages.subList(0, limit);
+            }
+
+            // 메시지를 오래된 순으로 뒤집어서 반환
+            Collections.reverse(messages);
+
+            log.info("📥 최근 채팅 메시지 조회 완료: regionId={}, limit={}, actualSize={}",
+                    regionId, limit, messages.size());
+
+            return messages;
+
+        } catch (Exception e) {
+            log.error("❌ 최근 채팅 메시지 조회 실패: regionId={}", regionId, e);
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * 특정 지역의 총 메시지 개수를 조회합니다.
+     *
+     * @param regionId 지역 ID
+     * @return 메시지 개수
+     */
+    public Long getMessageCount(Long regionId) {
+        try {
+            return chatMessageRepository.countByRegionId(regionId);
+        } catch (Exception e) {
+            log.error("❌ 메시지 개수 조회 실패: regionId={}", regionId, e);
+            return 0L;
+        }
+    }
+}
+

--- a/BE/HanaZoom/src/main/java/com/hanazoom/global/config/SecurityConfig.java
+++ b/BE/HanaZoom/src/main/java/com/hanazoom/global/config/SecurityConfig.java
@@ -39,7 +39,8 @@ public class SecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOriginPatterns(Arrays.asList("http://localhost:3000", "http://localhost:3001"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
-        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "X-Requested-With", "Accept", "Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers"));
+        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "X-Requested-With", "Accept",
+                "Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers"));
         configuration.setAllowCredentials(true);
         configuration.setMaxAge(3600L);
 
@@ -87,6 +88,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/pb-rooms/join-info").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/pb-rooms/*/join").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/pb-rooms/user/join").permitAll()
+                        .requestMatchers("/api/v1/calendar/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/portfolio/client/*/summary").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/portfolio/client/*/stocks").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/portfolio/client/*/trades").authenticated()

--- a/BE/HanaZoom/src/main/java/com/hanazoom/global/controller/EcosController.java
+++ b/BE/HanaZoom/src/main/java/com/hanazoom/global/controller/EcosController.java
@@ -1,0 +1,59 @@
+package com.hanazoom.global.controller;
+
+import com.hanazoom.global.dto.ApiResponse;
+import com.hanazoom.global.service.EcosApiService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 한국은행 ECOS API 컨트롤러 (디버깅용)
+ * 실제 경제지표 데이터를 제공하는 REST API 엔드포인트
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/ecos")
+@RequiredArgsConstructor
+public class EcosController {
+
+    private final EcosApiService ecosApiService;
+
+    /**
+     * 금주 금융 캘린더 조회
+     * GET /api/v1/ecos/weekly-schedule
+     */
+    @GetMapping("/weekly-schedule")
+    public ResponseEntity<ApiResponse<List<Map<String, Object>>>> getWeeklyFinancialCalendar() {
+        try {
+            log.info("주간 금융 캘린더 조회 요청");
+
+            ResponseEntity<Map<String, Object>> response = ecosApiService.getWeeklyFinancialCalendar();
+
+            log.info("서비스 응답 상태: {}", response.getStatusCode());
+            log.info("서비스 응답 본문: {}", response.getBody());
+
+            if (response.getBody() != null && (Boolean) response.getBody().get("success")) {
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> data = (List<Map<String, Object>>) response.getBody().get("data");
+                String message = (String) response.getBody().get("message");
+                return ResponseEntity.ok(ApiResponse.success(data, message));
+            } else {
+                String message = response.getBody() != null ? (String) response.getBody().get("message")
+                        : "주간 금융 캘린더 조회에 실패했습니다.";
+                log.error("서비스 응답 실패: {}", message);
+                return ResponseEntity.badRequest().body(ApiResponse.error(message));
+            }
+
+        } catch (Exception e) {
+            log.error("주간 금융 캘린더 조회 중 오류 발생", e);
+            return ResponseEntity.internalServerError()
+                    .body(ApiResponse.error("주간 금융 캘린더 조회 중 오류가 발생했습니다: " + e.getMessage()));
+        }
+    }
+}

--- a/BE/HanaZoom/src/main/java/com/hanazoom/global/controller/FinancialCalendarController.java
+++ b/BE/HanaZoom/src/main/java/com/hanazoom/global/controller/FinancialCalendarController.java
@@ -1,0 +1,51 @@
+package com.hanazoom.global.controller;
+
+import com.hanazoom.global.dto.ApiResponse;
+import com.hanazoom.global.dto.FinancialCalendarDto;
+import com.hanazoom.global.service.FinancialCalendarService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+/**
+ * 금융 캘린더 API 컨트롤러
+ * ECOS 기반 주간 경제지표 캘린더 제공
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/calendar")
+@RequiredArgsConstructor
+public class FinancialCalendarController {
+
+    private final FinancialCalendarService financialCalendarService;
+
+    /**
+     * 주간 금융 캘린더 조회
+     * GET /api/v1/calendar/weekly?baseDate=YYYY-MM-DD&includeAll=true|false
+     */
+    @GetMapping("/weekly")
+    public ResponseEntity<ApiResponse<FinancialCalendarDto>> getWeeklyFinancialCalendar(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate baseDate,
+            @RequestParam(defaultValue = "false") boolean includeAll) {
+
+        try {
+            log.info("주간 금융 캘린더 조회 요청 - baseDate: {}, includeAll: {}",
+                    baseDate != null ? baseDate : "현재일", includeAll);
+
+            FinancialCalendarDto calendar = financialCalendarService.getWeeklyCalendar(baseDate, includeAll);
+
+            log.info("주간 금융 캘린더 조회 성공 - {}개 지표 반환", calendar.getItems().length);
+            return ResponseEntity.ok(ApiResponse.success(calendar, "주간 금융 캘린더 조회 성공"));
+
+        } catch (Exception e) {
+            log.error("주간 금융 캘린더 조회 중 오류 발생", e);
+            return ResponseEntity.internalServerError()
+                    .body(ApiResponse.error("주간 금융 캘린더 조회 중 오류가 발생했습니다: " + e.getMessage()));
+        }
+    }
+}
+

--- a/BE/HanaZoom/src/main/java/com/hanazoom/global/dto/FinancialCalendarDto.java
+++ b/BE/HanaZoom/src/main/java/com/hanazoom/global/dto/FinancialCalendarDto.java
@@ -1,0 +1,61 @@
+package com.hanazoom.global.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 금융 캘린더 응답 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FinancialCalendarDto {
+    private WeekInfo week;
+    private FinancialScheduleItem[] items;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class WeekInfo {
+        @JsonProperty("baseDate")
+        private String baseDate;
+
+        private String start;
+        private String end;
+        private String timezone;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FinancialScheduleItem {
+        @JsonProperty("indicatorCode")
+        private String indicatorCode;
+
+        @JsonProperty("nameKo")
+        private String nameKo;
+
+        @JsonProperty("nameEn")
+        private String nameEn;
+
+        private String cycle;
+        private String unit;
+
+        @JsonProperty("scheduledDate")
+        private String scheduledDate;
+
+        @JsonProperty("publishedAt")
+        private String publishedAt;
+
+        @JsonProperty("timeKey")
+        private String timeKey;
+
+        private String previous;
+        private String actual;
+        private String status;
+        private String source;
+    }
+}
+

--- a/BE/HanaZoom/src/main/java/com/hanazoom/global/service/EcosApiService.java
+++ b/BE/HanaZoom/src/main/java/com/hanazoom/global/service/EcosApiService.java
@@ -1,0 +1,309 @@
+package com.hanazoom.global.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.TextStyle;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * 한국은행 ECOS API 서비스 (디버깅용)
+ * 실제 경제지표 데이터를 제공하는 공식 API 연동
+ */
+@Slf4j
+@Service
+public class EcosApiService {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Value("${ecos.api.key}")
+    private String bokApiKey;
+
+    // ECOS API 기본 URL
+    private static final String ECOS_API_BASE_URL = "https://ecos.bok.or.kr/api";
+    private static final String SERVICE_NAME = "StatisticSearch";
+    private static final String REQUEST_TYPE = "json";
+    private static final String LANGUAGE = "kr";
+
+    public EcosApiService() {
+        this.restTemplate = new RestTemplate();
+        this.objectMapper = new ObjectMapper();
+    }
+
+    /**
+     * 금주 금융 캘린더 조회 (한국은행 Open API 연동)
+     */
+    public ResponseEntity<Map<String, Object>> getWeeklyFinancialCalendar() {
+        try {
+            Map<String, Object> result = new HashMap<>();
+
+            // 현재 날짜 기준으로 금주 금융 일정 조회
+            LocalDate today = LocalDate.now();
+            LocalDate weekStart = today.with(DayOfWeek.MONDAY);
+            LocalDate weekEnd = today.with(DayOfWeek.SUNDAY);
+
+            log.info("금주 금융 캘린더 조회: {} ~ {}", weekStart, weekEnd);
+
+            // API 키 확인
+            log.info("API 키 존재 여부: {}", bokApiKey != null ? "있음" : "없음");
+            if (bokApiKey != null) {
+                log.info("API 키 첫 10자: {}", bokApiKey.substring(0, Math.min(10, bokApiKey.length())));
+            }
+
+            // 한국은행 API 호출
+            List<Map<String, Object>> weeklySchedule = getKoreaBankFinancialCalendar(weekStart, weekEnd);
+
+            // 실제 API에서 가져온 데이터인지 확인
+            boolean isRealData = isRealDataFromApi(weeklySchedule);
+
+            log.info("조회된 데이터 개수: {}", weeklySchedule.size());
+            log.info("실제 데이터 여부: {}", isRealData);
+
+            result.put("success", true);
+            result.put("data", weeklySchedule);
+            result.put("isRealData", isRealData);
+            result.put("message", isRealData ? "금주 실제 금융 캘린더를 조회했습니다." : "금주 금융 캘린더를 조회했습니다. (일부 데이터는 예상치입니다)");
+            result.put("period", Map.of(
+                    "start", weekStart.toString(),
+                    "end", weekEnd.toString(),
+                    "current", today.toString()));
+
+            return ResponseEntity.ok(result);
+
+        } catch (Exception e) {
+            log.error("주간 금융 캘린더 조회 중 오류 발생", e);
+            Map<String, Object> errorResult = new HashMap<>();
+            errorResult.put("success", false);
+            errorResult.put("isRealData", false);
+            errorResult.put("message", "금주 금융 캘린더 조회 중 오류가 발생했습니다: " + e.getMessage());
+            errorResult.put("error", "한국은행 API 호출 실패 - API 키 또는 네트워크 오류");
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResult);
+        }
+    }
+
+    /**
+     * 한국은행 API에서 금주 금융 캘린더 조회
+     */
+    private List<Map<String, Object>> getKoreaBankFinancialCalendar(LocalDate weekStart, LocalDate weekEnd) {
+        List<Map<String, Object>> scheduleList = new ArrayList<>();
+
+        try {
+            // API 키 조회 및 유효성 검사
+            if (bokApiKey == null || bokApiKey.isEmpty() || bokApiKey.equals("your_korean_bank_api_key_here")) {
+                log.warn("한국은행 API 키가 설정되지 않았습니다. application.properties의 ecos.api.key를 확인하세요.");
+                log.warn("API 키 값: '{}'", bokApiKey);
+                return getEmptyFinancialCalendar();
+            }
+
+            // 주요 금융 지표 통계 코드들
+            Map<String, String> financialIndicators = Map.of(
+                    "소비자물가지수", "901Y009",
+                    "산업생산지수", "901Y015",
+                    "실업률", "901Y086",
+                    "수출", "901Y013",
+                    "수입", "901Y014",
+                    "GDP", "901Y003",
+                    "제조업PMI", "901Y081",
+                    "주택가격지수", "901Y082");
+
+            log.info("조회할 지표 목록:");
+            financialIndicators.forEach((name, code) -> log.info("- {}: {}", name, code));
+
+            // 각 지표별로 데이터 조회
+            for (Map.Entry<String, String> entry : financialIndicators.entrySet()) {
+                String indicatorName = entry.getKey();
+                String statCode = entry.getValue();
+
+                log.info("지표 '{}' (코드: {}) 데이터 조회 시작", indicatorName, statCode);
+
+                try {
+                    List<Map<String, Object>> indicatorData = getKoreaBankIndicatorData(bokApiKey, statCode,
+                            indicatorName, weekStart, weekEnd);
+
+                    log.info("지표 '{}'에서 {}개의 데이터 조회됨", indicatorName, indicatorData.size());
+
+                    scheduleList.addAll(indicatorData);
+                } catch (Exception e) {
+                    log.warn("지표 {} 데이터 조회 실패: {}", indicatorName, e.getMessage());
+                    log.debug("지표 {} 조회 실패 상세: ", indicatorName, e);
+                }
+            }
+
+            log.info("한국은행에서 총 {}개의 금융 일정을 조회했습니다.", scheduleList.size());
+
+        } catch (Exception e) {
+            log.error("한국은행 API 호출 실패", e);
+            return getEmptyFinancialCalendar();
+        }
+
+        return scheduleList.isEmpty() ? getEmptyFinancialCalendar() : scheduleList;
+    }
+
+    /**
+     * 한국은행 통계 데이터 조회
+     */
+    private List<Map<String, Object>> getKoreaBankIndicatorData(String apiKey, String statCode, String indicatorName,
+            LocalDate weekStart, LocalDate weekEnd) {
+        List<Map<String, Object>> indicatorData = new ArrayList<>();
+
+        try {
+            // 한국은행 통계 데이터 조회 API
+            String dataUrl = String.format(
+                    "%s/%s/%s/%s/1/1000/%s/D/%s/%s",
+                    ECOS_API_BASE_URL, SERVICE_NAME, apiKey, REQUEST_TYPE, LANGUAGE, statCode,
+                    weekStart.format(DateTimeFormatter.ofPattern("yyyyMMdd")),
+                    weekEnd.format(DateTimeFormatter.ofPattern("yyyyMMdd")));
+
+            log.info("한국은행 API URL: {}", dataUrl);
+
+            ResponseEntity<String> response = restTemplate.getForEntity(dataUrl, String.class);
+
+            log.info("API 응답 상태 코드: {}", response.getStatusCode());
+            log.info("API 응답 본문: {}", response.getBody());
+
+            if (response.getStatusCode() == HttpStatus.OK) {
+                return parseKoreaBankResponse(response.getBody(), indicatorName);
+            } else {
+                log.warn("한국은행 통계 데이터 응답 오류: {}", response.getStatusCode());
+            }
+
+        } catch (Exception e) {
+            log.error("한국은행 통계 데이터 조회 실패: {}", indicatorName, e);
+        }
+
+        return indicatorData;
+    }
+
+    /**
+     * 한국은행 API 응답 파싱
+     */
+    private List<Map<String, Object>> parseKoreaBankResponse(String responseBody, String indicatorName) {
+        List<Map<String, Object>> scheduleList = new ArrayList<>();
+
+        try {
+            log.info("파싱할 응답 본문: {}", responseBody);
+
+            JsonNode rootNode = objectMapper.readTree(responseBody);
+
+            if (rootNode.has("StatisticSearch") && rootNode.get("StatisticSearch").has("row")) {
+                JsonNode rows = rootNode.get("StatisticSearch").get("row");
+
+                if (rows.isArray()) {
+                    log.info("응답에서 {}개의 행 발견", rows.size());
+
+                    for (JsonNode row : rows) {
+                        try {
+                            log.info("파싱할 행: {}", row.toString());
+
+                            Map<String, Object> schedule = new HashMap<>();
+
+                            // 통계 항목명
+                            String itemName = getTextValue(row, "ITEM_NAME");
+                            String unitName = getTextValue(row, "UNIT_NAME");
+
+                            if (itemName != null) {
+                                schedule.put("indicator", itemName + (unitName != null ? " (" + unitName + ")" : ""));
+
+                                // 발표 시간 (한국은행 표준 발표 시간)
+                                schedule.put("time", "08:00");
+
+                                // 발표 날짜 (실제 발표일 기준)
+                                String timeValue = getTextValue(row, "TIME");
+                                if (timeValue != null && timeValue.length() >= 8) {
+                                    String dateStr = timeValue.substring(0, 8);
+                                    LocalDate eventDate = LocalDate.of(
+                                            Integer.parseInt(dateStr.substring(0, 4)),
+                                            Integer.parseInt(dateStr.substring(4, 6)),
+                                            Integer.parseInt(dateStr.substring(6, 8)));
+
+                                    schedule.put("date", eventDate.toString());
+
+                                    // 요일 계산
+                                    String dayOfWeek = eventDate.getDayOfWeek().getDisplayName(TextStyle.FULL,
+                                            Locale.KOREAN);
+                                    schedule.put("dayOfWeek", dayOfWeek);
+                                }
+
+                                // 중요도 설정
+                                schedule.put("importance", "high");
+                                schedule.put("country", "한국");
+
+                                // 데이터 값
+                                String dataValue = getTextValue(row, "DATA_VALUE");
+                                if (dataValue != null) {
+                                    schedule.put("forecast", dataValue);
+                                }
+
+                                scheduleList.add(schedule);
+                                log.info("한국은행 지표 추가: {} - {} ({})", schedule.get("date"), schedule.get("time"),
+                                        itemName);
+                            } else {
+                                log.warn("ITEM_NAME이 null인 행 발견: {}", row.toString());
+                            }
+
+                        } catch (Exception e) {
+                            log.warn("개별 한국은행 데이터 파싱 실패", e);
+                        }
+                    }
+                } else {
+                    log.warn("응답의 row가 배열이 아님: {}", rows.getNodeType());
+                }
+            } else {
+                log.warn("응답에서 StatisticSearch 또는 row를 찾을 수 없음");
+                log.info("전체 응답 구조: {}", rootNode.toString());
+            }
+
+        } catch (Exception e) {
+            log.error("한국은행 응답 파싱 실패", e);
+        }
+
+        return scheduleList;
+    }
+
+    /**
+     * API 실패 시 빈 리스트 반환 (더미 데이터 제공하지 않음)
+     */
+    private List<Map<String, Object>> getEmptyFinancialCalendar() {
+        log.warn("❌ 한국은행 API 호출 실패 - 빈 데이터 반환 (사용자에게 데이터 없음 표시)");
+        return new ArrayList<>();
+    }
+
+    /**
+     * 실제 API에서 가져온 데이터인지 확인
+     */
+    private boolean isRealDataFromApi(List<Map<String, Object>> scheduleList) {
+        if (scheduleList == null || scheduleList.isEmpty()) {
+            log.info("데이터 리스트가 비어있거나 null임 - 실제 데이터 아님");
+            return false;
+        }
+
+        // 실제 데이터는 한국은행 API에서 온 것이므로 실제 데이터
+        boolean hasRealData = scheduleList.stream()
+                .anyMatch(item -> "한국".equals(item.get("country")));
+
+        log.info("실제 데이터 확인 결과: {}", hasRealData);
+        return hasRealData;
+    }
+
+    /**
+     * JSON 노드에서 텍스트 값 추출
+     */
+    private String getTextValue(JsonNode node, String fieldName) {
+        JsonNode fieldNode = node.get(fieldName);
+        return fieldNode != null && !fieldNode.isNull() ? fieldNode.asText() : null;
+    }
+}

--- a/BE/HanaZoom/src/main/java/com/hanazoom/global/service/FinancialCalendarService.java
+++ b/BE/HanaZoom/src/main/java/com/hanazoom/global/service/FinancialCalendarService.java
@@ -1,0 +1,717 @@
+package com.hanazoom.global.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hanazoom.global.dto.FinancialCalendarDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 금융 캘린더 서비스
+ * ECOS API 기반 주간 경제지표 캘린더 제공
+ */
+@Slf4j
+@Service
+public class FinancialCalendarService {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Value("${ecos.api.key}")
+    private String ecosApiKey;
+
+    // ECOS API 기본 설정
+    private static final String ECOS_BASE_URL = "https://ecos.bok.or.kr/api";
+    private static final String SERVICE_NAME = "StatisticSearch";
+    private static final String REQUEST_TYPE = "xml";
+    private static final String LANGUAGE = "kr";
+    private static final String TIMEZONE = "Asia/Seoul";
+
+    // 인메모리 캐시 (TTL 5분)
+    private final Map<String, CacheEntry> cache = new ConcurrentHashMap<>();
+    private static final long CACHE_TTL_MINUTES = 5;
+
+    // 지표 정의 (확인된 실제 통계표코드 사용)
+    private static final Map<String, IndicatorDefinition> INDICATORS = Map.of(
+            "CPI_M", new IndicatorDefinition(
+                    "901Y009", "0", "소비자물가지수", "Consumer Price Index",
+                    "M", "2020=100", "매월 2일"),
+            "IP_M", new IndicatorDefinition(
+                    "901Y015", "0", "산업생산지수", "Industrial Production Index",
+                    "M", "2020=100", "매월 말일"),
+            "GDP_Q_ADV", new IndicatorDefinition(
+                    "200Y001", "10101", "GDP성장률(전기대비)", "GDP Growth Rate",
+                    "Q", "%", "분기 종료 후 45일"),
+            "UNEMPLOYMENT", new IndicatorDefinition(
+                    "901Y086", "0", "실업률", "Unemployment Rate",
+                    "M", "%", "매월 말일"),
+            "CURRENT_ACCOUNT", new IndicatorDefinition(
+                    "903Y001", "0", "경상수지", "Current Account Balance",
+                    "M", "백만달러", "익월 말일"));
+
+    public FinancialCalendarService() {
+        this.restTemplate = new RestTemplate();
+        this.objectMapper = new ObjectMapper();
+    }
+
+    /**
+     * 주간 금융 캘린더 조회
+     */
+    public FinancialCalendarDto getWeeklyCalendar(LocalDate baseDate, boolean includeAll) {
+        // baseDate가 null이면 현재일 사용 (한국 시간대 기준)
+        LocalDate targetDate = baseDate != null ? baseDate : LocalDate.now(java.time.ZoneId.of("Asia/Seoul"));
+        log.info("현재 한국 날짜: {} (서버 Instant: {})", targetDate, java.time.Instant.now());
+
+        // 올바른 주간 계산 (현재 날짜가 속한 주의 월요일~일요일)
+        LocalDate weekStart = targetDate.with(DayOfWeek.MONDAY);
+        LocalDate weekEnd = targetDate.with(DayOfWeek.SUNDAY);
+
+        // 2025-09-29의 경우 weekStart는 2025-09-22, weekEnd는 2025-09-28
+        // 하지만 2025-09-29는 화요일이므로 다음 주간으로 조정
+        if (targetDate.getDayOfWeek() == DayOfWeek.MONDAY) {
+            // 월요일인 경우 현재 주간
+            log.info("📅 {} - 월요일, 현재 주간 사용: {} ~ {}", targetDate, weekStart, weekEnd);
+        } else {
+            // 화요일 이후인 경우 다음 주간으로 조정
+            weekStart = weekStart.plusWeeks(1);
+            weekEnd = weekEnd.plusWeeks(1);
+            log.info("📅 {} - {}, 다음 주간 사용: {} ~ {}", targetDate, targetDate.getDayOfWeek(), weekStart, weekEnd);
+        }
+
+        log.info("주간 금융 캘린더 계산 - 기준일: {}, 주간: {} ~ {}",
+                targetDate, weekStart, weekEnd);
+        log.info("최근 발표 데이터 기준일 계산 시작 - 현재기준: {}", targetDate);
+
+        // 주간 정보 생성
+        FinancialCalendarDto.WeekInfo weekInfo = new FinancialCalendarDto.WeekInfo(
+                targetDate.toString(),
+                weekStart.toString(),
+                weekEnd.toString(),
+                TIMEZONE);
+
+        // 지표 수집
+        List<FinancialCalendarDto.FinancialScheduleItem> items = new ArrayList<>();
+
+        // 캐시 초기화 (테스트용)
+        cache.clear();
+        log.info("캐시 초기화 완료");
+
+        for (Map.Entry<String, IndicatorDefinition> entry : INDICATORS.entrySet()) {
+            String indicatorCode = entry.getKey();
+            IndicatorDefinition definition = entry.getValue();
+
+            try {
+                log.info("📊 {} 처리 시작", definition.getNameKo());
+
+                // 발표 예정일 계산
+                LocalDate scheduledDate = calculateScheduledDate(definition, targetDate);
+                log.debug("발표 예정일: {}", scheduledDate);
+
+                // 해당 주차에 포함되는지 확인 (발표 예정)
+                boolean inRange = isInWeekRange(scheduledDate, weekStart, weekEnd, includeAll);
+
+                FinancialCalendarDto.FinancialScheduleItem item = null;
+
+                if (inRange) {
+                    // 발표 예정 지표 처리 - 현재 주간에 발표되는 지표
+                    log.info("📅 {} - 이번 주 발표 예정", definition.getNameKo());
+
+                    // 아직 발표되지 않았으므로 이전 발표 데이터를 조회
+                    item = processRecentIndicator(definition, targetDate);
+
+                    if (item != null) {
+                        log.info("📅 {} - 발표 예정 (최근 데이터 표시)", definition.getNameKo());
+                    } else {
+                        log.warn("📅 {} - 발표 예정 데이터 없음", definition.getNameKo());
+                        item = null;
+                    }
+                } else {
+                    // 발표 예정이 아니면 실제 발표된 최근 데이터 확인
+                    log.info("📈 {} - 최근 발표 데이터 조회", definition.getNameKo());
+                    item = processRecentIndicator(definition, targetDate);
+                }
+
+                if (item != null) {
+                    log.info("✅ {} 완료: {}", definition.getNameKo(), item.getActual());
+                    items.add(item);
+                } else {
+                    log.warn("❌ {} 실패", definition.getNameKo());
+                }
+
+            } catch (Exception e) {
+                log.error("💥 {} 처리 중 오류: {}", definition.getNameKo(), e.getMessage());
+            }
+        }
+
+        log.info("총 {}개 지표 수집 완료", items.size());
+        return new FinancialCalendarDto(weekInfo, items.toArray(new FinancialCalendarDto.FinancialScheduleItem[0]));
+    }
+
+    /**
+     * 발표 예정 지표 처리
+     */
+    private FinancialCalendarDto.FinancialScheduleItem processScheduledIndicator(
+            IndicatorDefinition definition, LocalDate scheduledDate, LocalDate targetDate) {
+
+        // 캐시 키 생성
+        String cacheKey = generateCacheKey(definition, targetDate);
+
+        // 캐시 확인
+        FinancialCalendarDto.FinancialScheduleItem item = getFromCache(cacheKey);
+
+        if (item == null) {
+            log.debug("📡 {} API 호출", definition.getNameKo());
+            // ECOS API에서 데이터 조회
+            item = fetchFromEcos(definition, scheduledDate);
+            if (item == null || item.getActual() == null) {
+                log.warn("❌ {} API 데이터 없음", definition.getNameKo());
+                item = null;
+            } else {
+                log.debug("✅ {} API 성공: {}", definition.getNameKo(), item.getActual());
+            }
+            // 실제 데이터만 캐시에 저장
+            if (item != null) {
+                cache.put(cacheKey, new CacheEntry(item, LocalDateTime.now().plusMinutes(CACHE_TTL_MINUTES)));
+            }
+        }
+
+        return item;
+    }
+
+    /**
+     * 최근 발표 지표 처리
+     */
+    private FinancialCalendarDto.FinancialScheduleItem processRecentIndicator(
+            IndicatorDefinition definition, LocalDate targetDate) {
+
+        try {
+            // 최근 발표 데이터 조회를 위해 조회 기간을 현재 월/분기 기준으로 설정
+            LocalDate recentDate = calculateRecentPublishedDate(definition, targetDate);
+            log.debug("📅 최근 발표 기준일: {}", recentDate);
+
+            // 캐시 키 생성 (최근 데이터용)
+            String recentCacheKey = generateRecentCacheKey(definition, targetDate);
+
+            // 캐시 확인
+            FinancialCalendarDto.FinancialScheduleItem item = getFromCache(recentCacheKey);
+
+            if (item == null) {
+                log.debug("📡 {} 최근 데이터 API 호출", definition.getNameKo());
+                // 최근 발표 데이터를 조회
+                item = fetchRecentFromEcos(definition, recentDate);
+                if (item == null || item.getActual() == null) {
+                    log.warn("❌ {} 최근 데이터 없음", definition.getNameKo());
+                    item = null;
+                } else {
+                    log.debug("✅ {} 최근 데이터 성공: {}", definition.getNameKo(), item.getActual());
+                }
+                // 실제 데이터만 캐시에 저장
+                if (item != null) {
+                    cache.put(recentCacheKey, new CacheEntry(item, LocalDateTime.now().plusMinutes(CACHE_TTL_MINUTES)));
+                }
+            }
+
+            return item;
+
+        } catch (Exception e) {
+            log.error("💥 {} 최근 데이터 처리 오류: {}", definition.getNameKo(), e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * 발표일 계산 (주말 보정 포함)
+     */
+    private LocalDate calculateScheduledDate(IndicatorDefinition definition, LocalDate baseDate) {
+        String rule = definition.getRule();
+        LocalDate scheduledDate;
+
+        if (rule.equals("매월 2일")) {
+            // 매월 2일 (다음달 2일)
+            LocalDate nextMonth = baseDate.plusMonths(1);
+            scheduledDate = nextMonth.withDayOfMonth(2);
+
+        } else if (rule.equals("매월 말일")) {
+            // 매월 말일 (이번달 말일)
+            scheduledDate = baseDate.withDayOfMonth(
+                    baseDate.withDayOfMonth(1).plusMonths(1).minusDays(1).getDayOfMonth());
+
+        } else if (rule.equals("익월 말일")) {
+            // 익월 말일 (다음달 말일)
+            LocalDate nextMonth = baseDate.plusMonths(1);
+            scheduledDate = nextMonth.withDayOfMonth(
+                    nextMonth.withDayOfMonth(1).plusMonths(1).minusDays(1).getDayOfMonth());
+
+        } else if (rule.startsWith("분기 종료 후 ")) {
+            // 분기 종료 후 D일
+            int daysAfter = Integer.parseInt(rule.replace("분기 종료 후 ", "").replace("일", ""));
+
+            // 해당 분기 계산 (기준일의 월요일이 속한 달의 분기)
+            LocalDate mondayOfWeek = baseDate.with(DayOfWeek.MONDAY);
+            int month = mondayOfWeek.getMonthValue();
+            int quarter = (month - 1) / 3 + 1;
+            int quarterStartMonth = (quarter - 1) * 3 + 1;
+            int quarterEndMonth = quarterStartMonth + 2;
+
+            LocalDate quarterEnd = LocalDate.of(baseDate.getYear(), quarterEndMonth, 1)
+                    .withDayOfMonth(1).plusMonths(1).minusDays(1);
+
+            scheduledDate = quarterEnd.plusDays(daysAfter);
+
+        } else {
+            throw new IllegalArgumentException("알 수 없는 규칙: " + rule);
+        }
+
+        // 주말 보정 (토/일이면 월요일로 이월)
+        if (scheduledDate.getDayOfWeek() == DayOfWeek.SATURDAY) {
+            scheduledDate = scheduledDate.plusDays(2); // 토요일 → 월요일
+        } else if (scheduledDate.getDayOfWeek() == DayOfWeek.SUNDAY) {
+            scheduledDate = scheduledDate.plusDays(1); // 일요일 → 월요일
+        }
+
+        return scheduledDate;
+    }
+
+    /**
+     * 최근 발표일 계산 (실제 발표된 데이터 조회용)
+     */
+    private LocalDate calculateRecentPublishedDate(IndicatorDefinition definition, LocalDate baseDate) {
+        String rule = definition.getRule();
+        LocalDate recentDate;
+
+        if (rule.equals("매월 2일")) {
+            // 매월 2일 발표 → 실제 발표된 데이터는 3개월 전 (2024년 데이터)
+            LocalDate prevMonth = baseDate.minusMonths(3);
+            recentDate = prevMonth.withDayOfMonth(2);
+
+        } else if (rule.equals("매월 말일")) {
+            // 매월 말일 발표 → 실제 발표된 데이터는 3개월 전
+            LocalDate prevMonth = baseDate.minusMonths(3);
+            recentDate = prevMonth.withDayOfMonth(
+                    prevMonth.withDayOfMonth(1).plusMonths(1).minusDays(1).getDayOfMonth());
+
+        } else if (rule.equals("익월 말일")) {
+            // 익월 말일 발표 → 실제 발표된 데이터는 3개월 전
+            LocalDate prevMonth = baseDate.minusMonths(3);
+            recentDate = prevMonth.withDayOfMonth(
+                    prevMonth.withDayOfMonth(1).plusMonths(1).minusDays(1).getDayOfMonth());
+
+        } else if (rule.startsWith("분기 종료 후 ")) {
+            // 분기 종료 후 D일 발표 → 실제 발표된 데이터는 2분기 전
+            int daysAfter = Integer.parseInt(rule.replace("분기 종료 후 ", "").replace("일", ""));
+
+            // 2분기 전 분기 계산 (실제 발표된 데이터 조회)
+            LocalDate mondayOfWeek = baseDate.with(DayOfWeek.MONDAY);
+            int month = mondayOfWeek.getMonthValue();
+            int quarter = (month - 1) / 3 + 1;
+            int prevQuarter = quarter - 2; // 2분기 전
+            if (prevQuarter < 1) {
+                prevQuarter = prevQuarter + 4;
+            }
+
+            int prevQuarterStartMonth = (prevQuarter - 1) * 3 + 1;
+            int prevQuarterEndMonth = prevQuarterStartMonth + 2;
+
+            int year = baseDate.getYear();
+            if (quarter <= 2) {
+                year = year - 1; // 2분기 전이 작년인 경우
+            }
+
+            LocalDate prevQuarterEnd = LocalDate.of(year, prevQuarterEndMonth, 1)
+                    .withDayOfMonth(1).plusMonths(1).minusDays(1);
+
+            recentDate = prevQuarterEnd.plusDays(daysAfter);
+
+        } else {
+            throw new IllegalArgumentException("알 수 없는 규칙: " + rule);
+        }
+
+        // 주말 보정 (토/일이면 월요일로 이월)
+        if (recentDate.getDayOfWeek() == DayOfWeek.SATURDAY) {
+            recentDate = recentDate.plusDays(2); // 토요일 → 월요일
+        } else if (recentDate.getDayOfWeek() == DayOfWeek.SUNDAY) {
+            recentDate = recentDate.plusDays(1); // 일요일 → 월요일
+        }
+
+        return recentDate;
+    }
+
+    /**
+     * 주차 범위 포함 확인
+     */
+    private boolean isInWeekRange(LocalDate scheduledDate, LocalDate weekStart, LocalDate weekEnd, boolean includeAll) {
+        log.debug("isInWeekRange 호출 - scheduledDate: {}, weekStart: {}, weekEnd: {}, includeAll: {}",
+                scheduledDate, weekStart, weekEnd, includeAll);
+
+        if (includeAll) {
+            log.debug("includeAll이 true이므로 모든 지표 포함");
+            return true; // 모든 지표 포함
+        }
+
+        boolean result = !scheduledDate.isBefore(weekStart) && !scheduledDate.isAfter(weekEnd);
+        log.debug("범위 체크 결과: {}", result);
+        return result;
+    }
+
+    /**
+     * ECOS API에서 데이터 조회
+     */
+    private FinancialCalendarDto.FinancialScheduleItem fetchFromEcos(IndicatorDefinition definition,
+            LocalDate scheduledDate) {
+        try {
+            // 조회 기간 설정 (발표월/분기의 이전/현재)
+            String startDate, endDate;
+
+            if (definition.getCycle().equals("M")) {
+                // scheduledDate 기준으로 실제 발표된 데이터 조회
+                LocalDate currentMonth = scheduledDate.withDayOfMonth(1);
+                LocalDate prevMonth = currentMonth.minusMonths(1);
+                startDate = prevMonth.format(DateTimeFormatter.ofPattern("yyyyMM"));
+                endDate = currentMonth.format(DateTimeFormatter.ofPattern("yyyyMM"));
+            } else { // 분기
+                LocalDate publishedQuarter = getQuarterStart(scheduledDate);
+                LocalDate prevQuarter = publishedQuarter.minusMonths(3);
+                startDate = prevQuarter.format(DateTimeFormatter.ofPattern("yyyyMM"));
+                endDate = publishedQuarter.format(DateTimeFormatter.ofPattern("yyyyMM"));
+            }
+
+            // API URL 구성 (StatisticSearch 형식)
+            String url = String.format("%s/%s/%s/%s/%s/1/100/%s/%s/%s/%s/%s",
+                    ECOS_BASE_URL, SERVICE_NAME, ecosApiKey, REQUEST_TYPE, LANGUAGE,
+                    definition.getStatCode(), definition.getCycle(),
+                    startDate, endDate,
+                    definition.getItem1());
+
+            log.debug("🔗 API URL: {}", url);
+
+            ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
+
+            if (response.getStatusCode() == HttpStatus.OK) {
+                return parseEcosResponse(definition, scheduledDate, response.getBody());
+            } else {
+                log.warn("❌ API 응답 오류: {}", response.getStatusCode());
+            }
+
+        } catch (Exception e) {
+            log.error("💥 API 호출 실패: {}", e.getMessage());
+        }
+
+        // 실패 시 null actual로 반환
+        return createEmptyItem(definition, scheduledDate);
+    }
+
+    /**
+     * 최근 발표 데이터를 위한 ECOS API 조회
+     */
+    private FinancialCalendarDto.FinancialScheduleItem fetchRecentFromEcos(IndicatorDefinition definition,
+            LocalDate recentDate) {
+        try {
+            // 최근 발표 데이터를 조회하기 위해 조회 기간 설정 (발표월/분기의 이전/현재)
+            String startDate, endDate;
+
+            if (definition.getCycle().equals("M")) {
+                // recentDate 기준으로 실제 발표된 데이터 조회
+                LocalDate currentMonth = recentDate.withDayOfMonth(1);
+                LocalDate prevMonth = currentMonth.minusMonths(1);
+                startDate = prevMonth.format(DateTimeFormatter.ofPattern("yyyyMM"));
+                endDate = currentMonth.format(DateTimeFormatter.ofPattern("yyyyMM"));
+            } else { // 분기
+                LocalDate publishedQuarter = getQuarterStart(recentDate);
+                LocalDate prevQuarter = publishedQuarter.minusMonths(3);
+                startDate = prevQuarter.format(DateTimeFormatter.ofPattern("yyyyMM"));
+                endDate = publishedQuarter.format(DateTimeFormatter.ofPattern("yyyyMM"));
+            }
+
+            // API URL 구성 (StatisticSearch 형식)
+            String url = String.format("%s/%s/%s/%s/%s/1/100/%s/%s/%s/%s/%s",
+                    ECOS_BASE_URL, SERVICE_NAME, ecosApiKey, REQUEST_TYPE, LANGUAGE,
+                    definition.getStatCode(), definition.getCycle(),
+                    startDate, endDate,
+                    definition.getItem1());
+
+            log.debug("🔗 최근 데이터 API URL: {}", url);
+
+            ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
+
+            if (response.getStatusCode() == HttpStatus.OK) {
+                return parseEcosResponse(definition, recentDate, response.getBody());
+            } else {
+                log.warn("❌ 최근 데이터 API 응답 오류: {}", response.getStatusCode());
+            }
+
+        } catch (Exception e) {
+            log.error("💥 최근 데이터 API 호출 실패: {}", e.getMessage());
+        }
+
+        // 실패 시 null actual로 반환
+        return createEmptyItem(definition, recentDate);
+    }
+
+    /**
+     * ECOS 응답 파싱 (StatisticSearch XML)
+     */
+    private FinancialCalendarDto.FinancialScheduleItem parseEcosResponse(
+            IndicatorDefinition definition, LocalDate scheduledDate, String responseBody) {
+
+        try {
+            log.debug("📄 XML 응답 파싱 중...");
+
+            // StatisticSearch 응답에서 DATA_VALUE 추출
+            String actual = extractStatisticSearchValue(responseBody);
+
+            if (actual != null) {
+                log.debug("✅ {} 데이터 추출: {}", definition.getNameKo(), actual);
+                return createTestItem(definition, scheduledDate, actual);
+            } else {
+                log.debug("❌ {} 데이터 없음", definition.getNameKo());
+                return null;
+            }
+
+        } catch (Exception e) {
+            log.error("💥 응답 파싱 실패: {}", e.getMessage());
+        }
+
+        return createEmptyItem(definition, scheduledDate);
+    }
+
+    /**
+     * 테스트용 아이템 생성
+     */
+    private FinancialCalendarDto.FinancialScheduleItem createTestItem(
+            IndicatorDefinition definition, LocalDate scheduledDate, String actual) {
+
+        String status = determineStatus(actual, scheduledDate);
+
+        return new FinancialCalendarDto.FinancialScheduleItem(
+                definition.getCode(),
+                definition.getNameKo(),
+                definition.getNameEn(),
+                definition.getCycle(),
+                definition.getUnitHint(),
+                scheduledDate.toString(),
+                status.equals("RELEASED")
+                        ? scheduledDate.atTime(8, 0, 0).toInstant(java.time.ZoneOffset.ofHours(9)).toString()
+                        : null,
+                definition.getRule(),
+                "전월: 2.3", // 이전값
+                actual, // 실제값
+                status,
+                "ECOS");
+    }
+
+    /**
+     * 빈 아이템 생성 (API 실패 시)
+     */
+    private FinancialCalendarDto.FinancialScheduleItem createEmptyItem(
+            IndicatorDefinition definition, LocalDate scheduledDate) {
+
+        String status = determineStatus(null, scheduledDate);
+
+        return new FinancialCalendarDto.FinancialScheduleItem(
+                definition.getCode(),
+                definition.getNameKo(),
+                definition.getNameEn(),
+                definition.getCycle(),
+                definition.getUnitHint(),
+                scheduledDate.toString(),
+                null,
+                definition.getRule(),
+                null,
+                null,
+                status,
+                "ECOS");
+    }
+
+    /**
+     * 상태 결정
+     */
+    private String determineStatus(String actual, LocalDate scheduledDate) {
+        LocalDate today = LocalDate.now();
+
+        if (actual != null && !actual.isEmpty()) {
+            return "RELEASED";
+        } else if (today.isAfter(scheduledDate)) {
+            return "DELAYED";
+        } else {
+            return "SCHEDULED";
+        }
+    }
+
+    /**
+     * 분기 시작일 계산
+     */
+    private LocalDate getQuarterStart(LocalDate date) {
+        int month = date.getMonthValue();
+        int quarter = (month - 1) / 3 + 1;
+        int quarterStartMonth = (quarter - 1) * 3 + 1;
+        return LocalDate.of(date.getYear(), quarterStartMonth, 1);
+    }
+
+    /**
+     * 캐시에서 조회
+     */
+    private FinancialCalendarDto.FinancialScheduleItem getFromCache(String cacheKey) {
+        CacheEntry entry = cache.get(cacheKey);
+        if (entry != null && entry.isValid()) {
+            return entry.getItem();
+        }
+        return null;
+    }
+
+    /**
+     * 캐시 키 생성
+     */
+    private String generateCacheKey(IndicatorDefinition definition, LocalDate baseDate) {
+        return String.format("%s|%s|%s|%s|%s",
+                definition.getStatCode(),
+                definition.getCycle(),
+                baseDate.getYear(),
+                baseDate.getMonthValue(),
+                definition.getItem1());
+    }
+
+    /**
+     * 최근 데이터용 캐시 키 생성
+     */
+    private String generateRecentCacheKey(IndicatorDefinition definition, LocalDate baseDate) {
+        return String.format("RECENT|%s|%s|%s|%s|%s",
+                definition.getStatCode(),
+                definition.getCycle(),
+                baseDate.getYear(),
+                baseDate.getMonthValue(),
+                definition.getItem1());
+    }
+
+    /**
+     * JSON 텍스트 값 추출 헬퍼
+     */
+    private String getTextValue(JsonNode node, String fieldName) {
+        JsonNode fieldNode = node.get(fieldName);
+        return fieldNode != null && !fieldNode.isNull() ? fieldNode.asText() : null;
+    }
+
+    /**
+     * StatisticSearch XML에서 DATA_VALUE 추출
+     */
+    private String extractStatisticSearchValue(String xmlResponse) {
+        try {
+            // 첫 번째 <row>의 <DATA_VALUE>를 찾기
+            int rowStart = xmlResponse.indexOf("<row>");
+            if (rowStart == -1) {
+                return null;
+            }
+
+            int rowEnd = xmlResponse.indexOf("</row>", rowStart) + 6;
+            if (rowEnd == -1) {
+                return null;
+            }
+
+            String rowContent = xmlResponse.substring(rowStart, rowEnd);
+
+            // DATA_VALUE 추출
+            int dataStart = rowContent.indexOf("<DATA_VALUE>");
+            int dataEnd = rowContent.indexOf("</DATA_VALUE>");
+
+            if (dataStart == -1 || dataEnd == -1) {
+                return null;
+            }
+
+            String dataValue = rowContent.substring(dataStart + 12, dataEnd);
+            return dataValue;
+
+        } catch (Exception e) {
+            log.error("XML 파싱 오류: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * 지표 정의 클래스
+     */
+    private static class IndicatorDefinition {
+        private final String statCode;
+        private final String item1;
+        private final String nameKo;
+        private final String nameEn;
+        private final String cycle;
+        private final String unitHint;
+        private final String rule;
+
+        public IndicatorDefinition(String statCode, String item1, String nameKo, String nameEn,
+                String cycle, String unitHint, String rule) {
+            this.statCode = statCode;
+            this.item1 = item1;
+            this.nameKo = nameKo;
+            this.nameEn = nameEn;
+            this.cycle = cycle;
+            this.unitHint = unitHint;
+            this.rule = rule;
+        }
+
+        // Getters
+        public String getStatCode() {
+            return statCode;
+        }
+
+        public String getItem1() {
+            return item1;
+        }
+
+        public String getNameKo() {
+            return nameKo;
+        }
+
+        public String getNameEn() {
+            return nameEn;
+        }
+
+        public String getCycle() {
+            return cycle;
+        }
+
+        public String getUnitHint() {
+            return unitHint;
+        }
+
+        public String getRule() {
+            return rule;
+        }
+
+        public String getCode() {
+            return this.getClass().getEnclosingClass().getSimpleName() + "_" + statCode;
+        }
+    }
+
+    /**
+     * 캐시 엔트리
+     */
+    private static class CacheEntry {
+        private final FinancialCalendarDto.FinancialScheduleItem item;
+        private final LocalDateTime expiryTime;
+
+        public CacheEntry(FinancialCalendarDto.FinancialScheduleItem item, LocalDateTime expiryTime) {
+            this.item = item;
+            this.expiryTime = expiryTime;
+        }
+
+        public boolean isValid() {
+            return LocalDateTime.now().isBefore(expiryTime);
+        }
+
+        public FinancialCalendarDto.FinancialScheduleItem getItem() {
+            return item;
+        }
+    }
+}

--- a/BE/HanaZoom/src/main/resources/application.properties
+++ b/BE/HanaZoom/src/main/resources/application.properties
@@ -33,6 +33,16 @@ spring.data.redis.lettuce.pool.max-wait=2000ms
 # Redis 재연결 설정
 spring.data.redis.lettuce.shutdown-timeout=200ms
 
+# MongoDB Configuration (for chat history)
+spring.data.mongodb.host=localhost
+spring.data.mongodb.port=27017
+spring.data.mongodb.database=hanazoom_chat
+spring.data.mongodb.username=hanazoom_mongo
+spring.data.mongodb.password=mongo1234!
+spring.data.mongodb.authentication-database=hanazoom_chat
+# MongoDB URI (대안적 설정 방법 - 위의 개별 설정보다 우선순위가 낮음)
+# spring.data.mongodb.uri=mongodb://hanazoom_mongo:mongo1234!@localhost:27017/hanazoom_chat?authSource=admin
+
 # Kakao API Settings
 kakao.rest-api-key=${KAKAO_REST_API_KEY:f50a1c0f8638ca30ef8c170a6ff8412b}
 

--- a/BE/HanaZoom/src/main/resources/application.properties
+++ b/BE/HanaZoom/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.application.name=HanaZoom
 spring.profiles.active=dev
 
 # Database Configuration (MySQL for Docker Compose)
-spring.datasource.url=jdbc:mysql://localhost:3306/hanazoom
+spring.datasource.url=jdbc:mysql://localhost:33306/hanazoom
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.username=hanazoom_user
 spring.datasource.password=hanazoom1234!
@@ -57,6 +57,9 @@ kis.app-key=${KIS_APP_KEY}
 kis.app-secret=${KIS_APP_SECRET}
 kis.account-code=${KIS_ACCOUNT_CODE}
 kis.product-code=${KIS_PRODUCT_CODE}
+
+# 한국은행 ECOS API Settings (디버깅용)
+ecos.api.key=3V6SOQXESD38Y5XWXVDW
 
 # DevTools Configuration
 spring.devtools.restart.enabled=true

--- a/BE/HanaZoom/src/main/resources/application.properties
+++ b/BE/HanaZoom/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.application.name=HanaZoom
 spring.profiles.active=dev
 
 # Database Configuration (MySQL for Docker Compose)
-spring.datasource.url=jdbc:mysql://localhost:33306/hanazoom
+spring.datasource.url=jdbc:mysql://localhost:3306/hanazoom
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.username=hanazoom_user
 spring.datasource.password=hanazoom1234!
@@ -68,7 +68,7 @@ spring.devtools.livereload.enabled=true
 # Logging Configuration
 logging.file.name=/var/log/hanazoom/backend.log
 logging.level.root=INFO
-logging.level.com.hanazoom=INFO
+logging.level.com.hanazoom=DEBUG
 logging.level.com.hanazoom.domain.stock.service.StockMinutePriceService=WARN
 logging.level.com.hanazoom.domain.stock.service.StockPriceService=WARN
 logging.level.com.hanazoom.domain.stock.service.StockWebSocketService=WARN

--- a/FE/app/page.tsx
+++ b/FE/app/page.tsx
@@ -6,13 +6,13 @@ import {
   MapPin,
   Users,
   Sparkles,
-  BarChart3,
   ChevronDown,
   ArrowRight,
   TrendingUp,
   TrendingDown,
   Map,
   LogIn,
+  Calendar,
 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -24,6 +24,7 @@ import { FloatingEmojiBackground } from "@/components/floating-emoji-background"
 import { useState, useEffect, useRef } from "react";
 import NavBar from "./components/Navbar";
 import { StockTicker } from "@/components/stock-ticker";
+import { FinancialCalendar } from "@/components/financial-calendar";
 import { isLoggedIn } from "./utils/auth";
 import { useUserSettingsStore } from "@/lib/stores/userSettingsStore";
 
@@ -34,6 +35,7 @@ export default function StockMapLanding() {
   const { settings, isInitialized } = useUserSettingsStore();
   const [scrolled, setScrolled] = useState(false);
   const [loggedIn, setLoggedIn] = useState(false);
+  const [isCalendarCollapsed, setIsCalendarCollapsed] = useState(false);
   const heroRef = useRef<HTMLDivElement>(null);
 
   const handleLoadingComplete = () => {
@@ -73,6 +75,13 @@ export default function StockMapLanding() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-50 to-emerald-100 dark:from-green-950 dark:to-emerald-950 overflow-hidden relative transition-colors duration-500">
+      {/* 금융 캘린더 사이드바 - 고정 위치 */}
+      <div className="fixed right-4 top-1/2 transform -translate-y-1/2 z-50">
+        <FinancialCalendar
+          isCollapsed={isCalendarCollapsed}
+          onToggle={() => setIsCalendarCollapsed(!isCalendarCollapsed)}
+        />
+      </div>
       {/* 마우스 따라다니는 아이콘들 (사용자 설정에 따라) */}
       {isInitialized && settings.customCursorEnabled && <MouseFollower />}
 
@@ -82,7 +91,9 @@ export default function StockMapLanding() {
       </div>
 
       {/* Floating Stock Symbols (사용자 설정에 따라) */}
-      {isInitialized && settings.emojiAnimationEnabled && <FloatingEmojiBackground />}
+      {isInitialized && settings.emojiAnimationEnabled && (
+        <FloatingEmojiBackground />
+      )}
 
       {/* NavBar 컴포넌트 사용 */}
       <div className="fixed top-0 left-0 right-0 z-[100]">
@@ -140,7 +151,9 @@ export default function StockMapLanding() {
                     <br />
                     지역별 투자 트렌드를 귀여운 지도로 확인해보세요 🗺️✨
                     <br />
-                    <span className="text-emerald-600 font-semibold">지역 특성을 반영한 맞춤형 주식 인사이트를 만나보세요!</span>
+                    <span className="text-emerald-600 font-semibold">
+                      지역 특성을 반영한 맞춤형 주식 인사이트를 만나보세요!
+                    </span>
                   </p>
                 </AnimateOnScroll>
 
@@ -246,7 +259,7 @@ export default function StockMapLanding() {
                 <Card className="bg-gradient-to-br from-green-50 to-emerald-50 dark:from-green-900/30 dark:to-emerald-900/30 border-green-200 dark:border-green-700 hover:shadow-lg dark:hover:shadow-green-900/20 transition-all duration-300 hover:scale-105 backdrop-blur-sm group">
                   <CardContent className="p-6 space-y-4">
                     <div className="w-12 h-12 bg-gradient-to-br from-emerald-400 to-green-500 dark:from-emerald-500 dark:to-green-400 rounded-full flex items-center justify-center shadow-lg group-hover:scale-110 transition-transform duration-300">
-                      <BarChart3 className="w-6 h-6 text-white" />
+                      <TrendingUp className="w-6 h-6 text-white" />
                     </div>
                     <h3 className="text-xl font-bold text-green-900 dark:text-green-100">
                       실시간 트렌드

--- a/FE/components/financial-calendar.tsx
+++ b/FE/components/financial-calendar.tsx
@@ -1,0 +1,351 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Calendar,
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  Clock,
+  AlertCircle,
+  ChevronDown,
+  ChevronUp,
+  X,
+} from "lucide-react";
+// 금융 캘린더 관련 타입과 API는 삭제됨 - 컴포넌트만 유지
+
+// 금융 일정 아이템 타입 정의
+interface FinancialScheduleItem {
+  date: string; // 발표 날짜 (YYYY-MM-DD)
+  dayOfWeek: string; // 요일
+  time: string; // 발표 시간
+  indicator: string; // 지표명
+  importance: string; // 중요도
+  country: string; // 국가
+  previous?: string; // 이전 값
+  forecast?: string; // 예상 값
+}
+
+// 금융 캘린더 컴포넌트 Props
+interface FinancialCalendarProps {
+  className?: string;
+  isCollapsed?: boolean;
+  onToggle?: () => void;
+  onClose?: () => void;
+}
+
+export function FinancialCalendar({
+  className = "",
+  isCollapsed = false,
+  onToggle,
+  onClose,
+}: FinancialCalendarProps) {
+  const [indicators, setIndicators] = useState<FinancialScheduleItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isRealData, setIsRealData] = useState<boolean>(false);
+
+  useEffect(() => {
+    // 더미 데이터 설정 (실제 API 연동이 삭제되어 더미 데이터만 표시)
+    setLoading(true);
+
+    // 더미 금융 일정 데이터
+    const dummyIndicators: FinancialScheduleItem[] = [
+      {
+        date: "2025-09-29",
+        dayOfWeek: "월요일",
+        time: "08:00",
+        indicator: "산업생산지수 (Industrial Production Index)",
+        importance: "high",
+        country: "한국",
+        forecast: "전월 대비 0.5%",
+        previous: "전월 대비 -0.3%",
+      },
+      {
+        date: "2025-10-01",
+        dayOfWeek: "수요일",
+        time: "08:00",
+        indicator: "소비자물가지수 (CPI)",
+        importance: "high",
+        country: "한국",
+        forecast: "전년 대비 2.5%",
+        previous: "전년 대비 2.3%",
+      },
+      {
+        date: "2025-09-30",
+        dayOfWeek: "화요일",
+        time: "08:00",
+        indicator: "실업률 (Unemployment Rate)",
+        importance: "medium",
+        country: "한국",
+        forecast: "2.4%",
+        previous: "2.5%",
+      },
+    ];
+
+    // 더미 데이터 설정
+    setTimeout(() => {
+      setIndicators(dummyIndicators);
+      setIsRealData(false); // 더미 데이터임을 표시
+      setLoading(false);
+    }, 1000); // 로딩 효과를 위한 지연
+  }, []);
+
+  const getImportanceIcon = (importance: string) => {
+    switch (importance) {
+      case "high":
+        return <AlertCircle className="w-3 h-3 text-red-500" />;
+      case "medium":
+        return <AlertCircle className="w-3 h-3 text-yellow-500" />;
+      case "low":
+        return <AlertCircle className="w-3 h-3 text-gray-400" />;
+      default:
+        return <AlertCircle className="w-3 h-3 text-gray-400" />;
+    }
+  };
+
+  const getImportanceLabel = (importance: string) => {
+    switch (importance) {
+      case "high":
+        return "높음";
+      case "medium":
+        return "중간";
+      case "low":
+        return "낮음";
+      default:
+        return "알 수 없음";
+    }
+  };
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const today = new Date();
+    const tomorrow = new Date(today);
+    tomorrow.setDate(today.getDate() + 1);
+
+    if (date.toDateString() === today.toDateString()) {
+      return "오늘";
+    } else if (date.toDateString() === tomorrow.toDateString()) {
+      return "내일";
+    } else {
+      return `${date.getMonth() + 1}월 ${date.getDate()}일`;
+    }
+  };
+
+  const isToday = (dateString: string) => {
+    const date = new Date(dateString);
+    const today = new Date();
+    return date.toDateString() === today.toDateString();
+  };
+
+  const renderIndicator = (indicator: FinancialScheduleItem, index: number) => {
+    return (
+      <div
+        key={`${indicator.date}-${indicator.indicator}-${index}`}
+        className={`p-2 rounded-lg border transition-all duration-200 hover:shadow-sm ${
+          isToday(indicator.date)
+            ? "bg-blue-50 border-blue-200 dark:bg-blue-900/20 dark:border-blue-700"
+            : "bg-white/80 border-gray-200 dark:bg-gray-800/80 dark:border-gray-700"
+        }`}
+      >
+        <div className="flex items-start justify-between">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-1 mb-1">
+              <div className="flex items-center gap-1">
+                <h4 className="font-semibold text-sm text-gray-900 dark:text-gray-100 truncate">
+                  {indicator.indicator}
+                </h4>
+              </div>
+              {getImportanceIcon(indicator.importance)}
+              <span className="text-xs text-gray-500 dark:text-gray-400">
+                {getImportanceLabel(indicator.importance)}
+              </span>
+            </div>
+
+            <div className="flex items-center gap-2 mb-1">
+              <div className="flex items-center gap-1">
+                <span className="font-mono font-bold text-sm text-gray-900 dark:text-gray-100">
+                  {indicator.forecast || "예측치 없음"}
+                </span>
+                <span className="text-xs text-gray-600 dark:text-gray-400">
+                  {indicator.previous ? "예측" : ""}
+                </span>
+              </div>
+
+              {indicator.previous && (
+                <div className="flex items-center gap-1">
+                  <span className="text-xs text-gray-600 dark:text-gray-400">
+                    이전:
+                  </span>
+                  <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                    {indicator.previous}
+                  </span>
+                </div>
+              )}
+            </div>
+
+            <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+              <div className="flex items-center gap-2">
+                <div className="flex items-center gap-1">
+                  <Calendar className="w-3 h-3" />
+                  <span>{formatDate(indicator.date)}</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <Clock className="w-3 h-3" />
+                  <span>{indicator.time}</span>
+                </div>
+              </div>
+              <div className="text-right">
+                <div className="font-medium">{indicator.dayOfWeek}</div>
+                <div className="text-xs text-gray-400">{indicator.country}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  if (loading) {
+    return (
+      <div
+        className={`bg-white/95 dark:bg-gray-800/95 backdrop-blur-sm rounded-lg border border-gray-200 dark:border-gray-700 p-3 ${className}`}
+      >
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-sm font-bold text-gray-900 dark:text-gray-100">
+            📅 금융 캘린더
+          </h3>
+          {onToggle && (
+            <button
+              onClick={onToggle}
+              className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+            >
+              {isCollapsed ? (
+                <ChevronDown className="w-3 h-3" />
+              ) : (
+                <ChevronUp className="w-3 h-3" />
+              )}
+            </button>
+          )}
+        </div>
+        <div className="space-y-2">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="p-2 rounded-lg border border-gray-200 dark:border-gray-700 animate-pulse"
+            >
+              <div className="flex items-center justify-between mb-1">
+                <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-3/4"></div>
+                <div className="h-2 bg-gray-200 dark:bg-gray-700 rounded w-12"></div>
+              </div>
+              <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/2 mb-1"></div>
+              <div className="flex justify-between">
+                <div className="h-2 bg-gray-200 dark:bg-gray-700 rounded w-16"></div>
+                <div className="h-2 bg-gray-200 dark:bg-gray-700 rounded w-20"></div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        className={`bg-white/95 dark:bg-gray-800/95 backdrop-blur-sm rounded-lg border border-red-200 dark:border-red-700 p-3 ${className}`}
+      >
+        <div className="text-center py-4">
+          <AlertCircle className="w-8 h-8 text-red-500 mx-auto mb-2" />
+          <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`bg-white/95 dark:bg-gray-800/95 backdrop-blur-sm rounded-lg border border-gray-200 dark:border-gray-700 p-3 shadow-lg ${className} ${
+        isCollapsed ? "w-12" : "w-80"
+      } transition-all duration-300`}
+    >
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <h3
+            className={`font-bold text-gray-900 dark:text-gray-100 ${
+              isCollapsed ? "text-xs" : "text-sm"
+            }`}
+          >
+            📅 금융 캘린더
+          </h3>
+          {/* 데이터 상태 표시 */}
+          {!isCollapsed && (
+            <div className="flex items-center gap-1">
+              {isRealData ? (
+                <div className="flex items-center gap-1 text-green-600 dark:text-green-400">
+                  <div className="w-2 h-2 bg-green-500 rounded-full"></div>
+                  <span className="text-xs">실제</span>
+                </div>
+              ) : (
+                <div className="flex items-center gap-1 text-gray-500 dark:text-gray-400">
+                  <div className="w-2 h-2 bg-gray-400 rounded-full"></div>
+                  <span className="text-xs">불러오는 중...</span>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+        <div className="flex items-center gap-1">
+          {onToggle && (
+            <button
+              onClick={onToggle}
+              className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+            >
+              {isCollapsed ? (
+                <ChevronUp className="w-3 h-3" />
+              ) : (
+                <ChevronDown className="w-3 h-3" />
+              )}
+            </button>
+          )}
+          {onClose && (
+            <button
+              onClick={onClose}
+              className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+            >
+              <X className="w-3 h-3" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {!isCollapsed && (
+        <div className="space-y-2 max-h-96 overflow-y-auto">
+          {indicators.length > 0 ? (
+            indicators.map((indicator, index) =>
+              renderIndicator(indicator, index)
+            )
+          ) : (
+            <div className="text-center py-8">
+              <Calendar className="w-8 h-8 text-gray-400 mx-auto mb-2" />
+              <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">
+                이번 주 금융 일정이 없습니다.
+              </p>
+              <p className="text-xs text-gray-400 dark:text-gray-500">
+                한국은행 API에서 데이터를 불러올 수 없습니다.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {isCollapsed && indicators.length > 0 && (
+        <div className="flex flex-col items-center gap-1">
+          <div className="w-2 h-2 bg-red-500 rounded-full"></div>
+          <div className="w-2 h-2 bg-yellow-500 rounded-full"></div>
+          <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/FE/components/korea-indicator-card.tsx
+++ b/FE/components/korea-indicator-card.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Calendar,
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  Clock,
+  AlertCircle,
+} from "lucide-react";
+// 금융 캘린더 관련 타입과 API는 삭제됨 - 더미 데이터만 사용
+
+// 금융 일정 아이템 타입 정의
+interface FinancialScheduleItem {
+  date: string; // 발표 날짜 (YYYY-MM-DD)
+  dayOfWeek: string; // 요일
+  time: string; // 발표 시간
+  indicator: string; // 지표명
+  importance: string; // 중요도
+  country: string; // 국가
+  previous?: string; // 이전 값
+  forecast?: string; // 예상 값
+}
+
+interface KoreaIndicatorCardProps {
+  className?: string;
+  showHeader?: boolean;
+  maxItems?: number;
+}
+
+export function KoreaIndicatorCard({
+  className = "",
+  showHeader = true,
+  maxItems,
+}: KoreaIndicatorCardProps) {
+  const [indicators, setIndicators] = useState<FinancialScheduleItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // 더미 데이터 설정 (실제 API 연동이 삭제되어 더미 데이터만 표시)
+    setLoading(true);
+
+    // 더미 금융 일정 데이터
+    const dummyIndicators: FinancialScheduleItem[] = [
+      {
+        date: "2025-09-29",
+        dayOfWeek: "월요일",
+        time: "08:00",
+        indicator: "산업생산지수 (Industrial Production Index)",
+        importance: "high",
+        country: "한국",
+        forecast: "전월 대비 0.5%",
+        previous: "전월 대비 -0.3%",
+      },
+      {
+        date: "2025-10-01",
+        dayOfWeek: "수요일",
+        time: "08:00",
+        indicator: "소비자물가지수 (CPI)",
+        importance: "high",
+        country: "한국",
+        forecast: "전년 대비 2.5%",
+        previous: "전년 대비 2.3%",
+      },
+      {
+        date: "2025-09-30",
+        dayOfWeek: "화요일",
+        time: "08:00",
+        indicator: "실업률 (Unemployment Rate)",
+        importance: "medium",
+        country: "한국",
+        forecast: "2.4%",
+        previous: "2.5%",
+      },
+    ];
+
+    // 더미 데이터 설정
+    setTimeout(() => {
+      setIndicators(
+        maxItems ? dummyIndicators.slice(0, maxItems) : dummyIndicators
+      );
+      setLoading(false);
+    }, 500); // 로딩 효과를 위한 지연
+  }, [maxItems]);
+
+  const getImportanceIcon = (importance: string) => {
+    switch (importance) {
+      case "high":
+        return <AlertCircle className="w-3 h-3 text-red-500" />;
+      case "medium":
+        return <AlertCircle className="w-3 h-3 text-yellow-500" />;
+      case "low":
+        return <AlertCircle className="w-3 h-3 text-gray-400" />;
+      default:
+        return <AlertCircle className="w-3 h-3 text-gray-400" />;
+    }
+  };
+
+  const getImportanceLabel = (importance: string) => {
+    switch (importance) {
+      case "high":
+        return "높음";
+      case "medium":
+        return "중간";
+      case "low":
+        return "낮음";
+      default:
+        return "알 수 없음";
+    }
+  };
+
+  const getChangeIcon = (changeType: string) => {
+    switch (changeType) {
+      case "positive":
+        return <TrendingUp className="w-3 h-3 text-green-500" />;
+      case "negative":
+        return <TrendingDown className="w-3 h-3 text-red-500" />;
+      default:
+        return <Minus className="w-3 h-3 text-gray-400" />;
+    }
+  };
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const today = new Date();
+    const tomorrow = new Date(today);
+    tomorrow.setDate(today.getDate() + 1);
+
+    if (date.toDateString() === today.toDateString()) {
+      return "오늘";
+    } else if (date.toDateString() === tomorrow.toDateString()) {
+      return "내일";
+    } else {
+      return `${date.getMonth() + 1}월 ${date.getDate()}일`;
+    }
+  };
+
+  const isToday = (dateString: string) => {
+    const date = new Date(dateString);
+    const today = new Date();
+    return date.toDateString() === today.toDateString();
+  };
+
+  const renderIndicator = (indicator: FinancialScheduleItem, index: number) => (
+    <div
+      key={`${indicator.date}-${indicator.indicator}-${index}`}
+      className={`p-3 rounded-lg border transition-all duration-200 hover:shadow-md ${
+        isToday(indicator.date)
+          ? "bg-blue-50 border-blue-200 dark:bg-blue-900/20 dark:border-blue-700"
+          : "bg-white border-gray-200 dark:bg-gray-800 dark:border-gray-700"
+      }`}
+    >
+      <div className="flex items-start justify-between">
+        <div className="flex-1">
+          <div className="flex items-center gap-2 mb-1">
+            <h3 className="font-semibold text-sm text-gray-900 dark:text-gray-100">
+              {indicator.indicator}
+            </h3>
+            {getImportanceIcon(indicator.importance)}
+            <span className="text-xs text-gray-500 dark:text-gray-400">
+              {getImportanceLabel(indicator.importance)}
+            </span>
+          </div>
+
+          <div className="flex items-center gap-3 mb-2">
+            <div className="flex items-center gap-1">
+              <span className="font-mono font-bold text-lg text-gray-900 dark:text-gray-100">
+                {indicator.forecast || "예측치 없음"}
+              </span>
+              <span className="text-sm text-gray-600 dark:text-gray-400">
+                {indicator.previous ? "예측" : ""}
+              </span>
+            </div>
+
+            {indicator.previous && (
+              <div className="flex items-center gap-1">
+                <span className="text-sm text-gray-600 dark:text-gray-400">
+                  이전:
+                </span>
+                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  {indicator.previous}
+                </span>
+              </div>
+            )}
+          </div>
+
+          <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+            <div className="flex items-center gap-3">
+              <div className="flex items-center gap-1">
+                <Calendar className="w-3 h-3" />
+                <span>{formatDate(indicator.date)}</span>
+              </div>
+              <div className="flex items-center gap-1">
+                <Clock className="w-3 h-3" />
+                <span>{indicator.time}</span>
+              </div>
+            </div>
+            <div className="text-right">
+              <div className="font-medium">{indicator.dayOfWeek}</div>
+              <div className="text-xs text-gray-400">{indicator.country}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  if (loading) {
+    return (
+      <div
+        className={`bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 ${className}`}
+      >
+        {showHeader && (
+          <div className="mb-4">
+            <h2 className="text-lg font-bold text-gray-900 dark:text-gray-100 mb-1">
+              🇰🇷 대한민국 지표발표
+            </h2>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              금주 주요 경제지표 발표 일정
+            </p>
+          </div>
+        )}
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="p-3 rounded-lg border border-gray-200 dark:border-gray-700 animate-pulse"
+            >
+              <div className="flex items-center justify-between mb-2">
+                <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-3/4"></div>
+                <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-16"></div>
+              </div>
+              <div className="h-6 bg-gray-200 dark:bg-gray-700 rounded w-1/2 mb-2"></div>
+              <div className="flex justify-between">
+                <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-20"></div>
+                <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-24"></div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        className={`bg-white dark:bg-gray-800 rounded-lg border border-red-200 dark:border-red-700 p-4 ${className}`}
+      >
+        <div className="text-center py-4">
+          <AlertCircle className="w-8 h-8 text-red-500 mx-auto mb-2" />
+          <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 ${className}`}
+    >
+      {showHeader && (
+        <div className="mb-4">
+          <h2 className="text-lg font-bold text-gray-900 dark:text-gray-100 mb-1">
+            🇰🇷 대한민국 금융 일정
+          </h2>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            금주 주요 금융 일정 및 경제지표 발표
+          </p>
+        </div>
+      )}
+
+      <div className="space-y-3">
+        {indicators.length > 0 ? (
+          indicators.map((indicator, index) =>
+            renderIndicator(indicator, index)
+          )
+        ) : (
+          <div className="text-center py-8">
+            <Calendar className="w-8 h-8 text-gray-400 mx-auto mb-2" />
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              이번 주 금융 일정을 불러올 수 없습니다.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/FE/lib/api/chat.ts
+++ b/FE/lib/api/chat.ts
@@ -1,0 +1,164 @@
+import { getAccessToken } from "@/app/utils/auth";
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8080";
+
+export interface RegionChatMessage {
+  id: string;
+  regionId: number;
+  memberId: string;
+  memberName: string;
+  content: string;
+  messageType: string;
+  createdAt: string;
+  images?: string[];
+  imageCount?: number;
+  portfolioStocks?: any[];
+}
+
+export interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  message?: string;
+}
+
+/**
+ * 특정 지역의 이전 채팅 메시지를 조회합니다.
+ *
+ * @param regionId 지역 ID
+ * @param page 페이지 번호 (기본값: 0)
+ * @param size 페이지 크기 (기본값: 50)
+ * @returns 채팅 메시지 목록
+ */
+export async function getRegionMessages(
+  regionId: number,
+  page: number = 0,
+  size: number = 50
+): Promise<RegionChatMessage[]> {
+  try {
+    const token = await getAccessToken();
+    if (!token) {
+      console.warn("인증 토큰이 없습니다.");
+      return [];
+    }
+
+    const response = await fetch(
+      `${API_BASE_URL}/api/v1/chat/region/${regionId}/messages?page=${page}&size=${size}`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      console.error("채팅 메시지 조회 실패:", response.statusText);
+      return [];
+    }
+
+    const result: ApiResponse<RegionChatMessage[]> = await response.json();
+
+    if (result.success && result.data) {
+      return result.data;
+    }
+
+    return [];
+  } catch (error) {
+    console.error("채팅 메시지 조회 중 오류 발생:", error);
+    return [];
+  }
+}
+
+/**
+ * 특정 지역의 최근 N개 메시지를 조회합니다.
+ *
+ * @param regionId 지역 ID
+ * @param limit 조회할 메시지 개수 (기본값: 50)
+ * @returns 최근 채팅 메시지 목록
+ */
+export async function getRecentMessages(
+  regionId: number,
+  limit: number = 50
+): Promise<RegionChatMessage[]> {
+  try {
+    const token = await getAccessToken();
+    if (!token) {
+      console.warn("인증 토큰이 없습니다.");
+      return [];
+    }
+
+    const response = await fetch(
+      `${API_BASE_URL}/api/v1/chat/region/${regionId}/recent?limit=${limit}`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      console.error("최근 채팅 메시지 조회 실패:", response.statusText);
+      return [];
+    }
+
+    const result: ApiResponse<RegionChatMessage[]> = await response.json();
+
+    if (result.success && result.data) {
+      return result.data;
+    }
+
+    return [];
+  } catch (error) {
+    console.error("최근 채팅 메시지 조회 중 오류 발생:", error);
+    return [];
+  }
+}
+
+/**
+ * 특정 지역의 총 메시지 개수를 조회합니다.
+ *
+ * @param regionId 지역 ID
+ * @returns 메시지 개수
+ */
+export async function getMessageCount(regionId: number): Promise<number> {
+  try {
+    const token = await getAccessToken();
+    if (!token) {
+      console.warn("인증 토큰이 없습니다.");
+      return 0;
+    }
+
+    const response = await fetch(
+      `${API_BASE_URL}/api/v1/chat/region/${regionId}/count`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      console.error("메시지 개수 조회 실패:", response.statusText);
+      return 0;
+    }
+
+    const result: ApiResponse<number> = await response.json();
+
+    if (result.success && result.data !== undefined) {
+      return result.data;
+    }
+
+    return 0;
+  } catch (error) {
+    console.error("메시지 개수 조회 중 오류 발생:", error);
+    return 0;
+  }
+}
+

--- a/Infra/docker-compose.yml
+++ b/Infra/docker-compose.yml
@@ -51,10 +51,37 @@ services:
     networks:
       - app-network
 
+  # MongoDB Service (for chat history)
+  mongodb:
+    image: mongo:7.0
+    ports:
+      - "27017:27017"
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=${MONGO_ROOT_USERNAME:-admin}
+      - MONGO_INITDB_ROOT_PASSWORD=${MONGO_ROOT_PASSWORD:-admin1234!}
+      - MONGO_INITDB_DATABASE=hanazoom_chat
+    volumes:
+      - mongodb_data:/data/db
+      - mongodb_config:/data/configdb
+      - ./mongodb/init:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 40s
+    restart: always
+    networks:
+      - app-network
+
 volumes:
   mysql_data:
     driver: local
   redis_data:
+    driver: local
+  mongodb_data:
+    driver: local
+  mongodb_config:
     driver: local
 
 networks:

--- a/Infra/env-template
+++ b/Infra/env-template
@@ -11,10 +11,19 @@ IMAGE_TAG=${ENV_SUFFIX}-latest
 SPRING_PROFILES_ACTIVE=${ENV_SUFFIX}
 NODE_ENV=${ENV_SUFFIX}
 
-# Database Settings
+# Database Settings (MySQL)
 DB_USERNAME=hanazoom_user
 DB_PASSWORD=your_secure_password
 DB_ROOT_PASSWORD=your_secure_root_password
+
+# Redis Settings
+REDIS_PASSWORD=redis1234!
+
+# MongoDB Settings (for chat history)
+MONGO_ROOT_USERNAME=admin
+MONGO_ROOT_PASSWORD=admin1234!
+MONGO_USERNAME=hanazoom_mongo
+MONGO_PASSWORD=mongo1234!
 
 # Logging
 LOG_LEVEL=info  # or debug for dev environment 

--- a/Infra/mongodb/init/01-create-user.js
+++ b/Infra/mongodb/init/01-create-user.js
@@ -1,0 +1,28 @@
+// MongoDB 사용자 생성 스크립트
+// Docker Compose의 MONGO_INITDB_ROOT_USERNAME은 root 사용자만 생성하므로
+// 애플리케이션용 일반 사용자를 별도로 생성해야 합니다.
+
+print("🔧 MongoDB 사용자 생성 시작...");
+
+// hanazoom_chat 데이터베이스로 전환
+db = db.getSiblingDB("hanazoom_chat");
+
+// 애플리케이션용 사용자 생성
+db.createUser({
+  user: "hanazoom_mongo",
+  pwd: "mongo1234!",
+  roles: [
+    {
+      role: "readWrite",
+      db: "hanazoom_chat",
+    },
+  ],
+});
+
+print("✅ hanazoom_mongo 사용자 생성 완료");
+
+// 컬렉션 생성 (선택사항 - 첫 메시지 저장 시 자동 생성됨)
+db.createCollection("region_chat_messages");
+
+print("✅ region_chat_messages 컬렉션 생성 완료");
+print("✅ MongoDB 초기화 완료!");

--- a/README.md
+++ b/README.md
@@ -17,29 +17,36 @@
 
 ## 🛠 기술 스택
 
-| 분야 | 기술 스택 |
-|------|-----------|
-| **Frontend** | Next.js, TypeScript, TailwindCSS, Kakao Maps API, Zustand, WebSocket |
-| **Backend** | Spring Boot, Spring Security + JWT, JPA(Hibernate), WebSocket, REST API |
-| **Database** | MySQL (지역/주식/회원/커뮤니티), Flyway (DB 마이그레이션 관리) |
-| **Infra** | Docker, Docker Compose, Nginx, GitHub Actions (CI/CD), AWS EC2 |
-| **ETC** | Kakao REST API (주소 → 좌표 변환), ESLint & Prettier (코드 스타일) |
+| 분야         | 기술 스택                                                               |
+| ------------ | ----------------------------------------------------------------------- |
+| **Frontend** | Next.js, TypeScript, TailwindCSS, Kakao Maps API, Zustand, WebSocket    |
+| **Backend**  | Spring Boot, Spring Security + JWT, JPA(Hibernate), WebSocket, REST API |
+| **Database** | MySQL (지역/주식/회원/커뮤니티), Flyway (DB 마이그레이션 관리)          |
+| **Infra**    | Docker, Docker Compose, Nginx, GitHub Actions (CI/CD), AWS EC2          |
+| **ETC**      | Kakao REST API (주소 → 좌표 변환), ESLint & Prettier (코드 스타일)      |
 
 ## 📦 프로젝트 구조
 
 ```
 
 HanaZoom/
-├── FE/                 # 프론트엔드
-│   ├── app/            # 페이지
-│   ├── components/     # 재사용 컴포넌트
-│   └── public/         # 정적 파일
-├── BE/                 # 백엔드
-│   └── HanaZoom/       # Spring Boot 프로젝트
-└── Infra/              # 인프라 설정
-└── mysql/          # DB 초기화 스크립트
+├── FE/                          # 프론트엔드
+│   ├── app/                     # 페이지 및 API 설정
+│   ├── components/              # 재사용 컴포넌트
+│   │   └── ...
+│   ├── data/                    # 실제 데이터 처리
+│   ├── lib/api/                 # API 함수
+│   ├── types/                   # 타입 정의
+│   └── public/                  # 정적 파일
+├── BE/                          # 백엔드
+│   └── HanaZoom/                # Spring Boot 프로젝트
+│       ├── global/service/      # 공통 서비스
+│       ├── global/controller/   # 공통 컨트롤러
+│       └── ...
+└── Infra/                       # 인프라 설정
 
-````
+```
+
 ## 🗂 아키텍처 다이어그램
 
 ```mermaid
@@ -60,13 +67,15 @@ flowchart TD
         F --> G[AWS EC2]
     end
 ```
+
 ## 🚀 시작하기
 
 ### Backend 실행
+
 ```bash
 cd BE/HanaZoom
 ./gradlew bootRun
-````
+```
 
 ### Frontend 실행
 
@@ -80,73 +89,73 @@ npm run dev
 
 ## 📊 데이터베이스 구조
 
-* **regions**: 지역 정보 (시/구/동 계층 구조, 좌표 포함)
-* **stocks**: 주식 종목 정보 (심볼, 이름, 시장, 섹터, 실시간 가격/변동률 등)
-* **region\_stocks**: 지역별 인기 종목 순위 및 인기도 점수
-* **members**: 사용자 계정, 주소/좌표, 지역 매핑 정보
-* **posts**: 커뮤니티 게시글 (일반/투표형, 좋아요, 댓글 수, 조회 수 등)
-* **comments**: 게시글 댓글 (좋아요 포함)
-* **polls / poll\_responses**: 투표형 게시글과 사용자 응답 관리
-* **likes**: 게시글/댓글 좋아요 내역
-* **attachments**: 게시글 첨부파일 메타데이터
+- **regions**: 지역 정보 (시/구/동 계층 구조, 좌표 포함)
+- **stocks**: 주식 종목 정보 (심볼, 이름, 시장, 섹터, 실시간 가격/변동률 등)
+- **region_stocks**: 지역별 인기 종목 순위 및 인기도 점수
+- **members**: 사용자 계정, 주소/좌표, 지역 매핑 정보
+- **posts**: 커뮤니티 게시글 (일반/투표형, 좋아요, 댓글 수, 조회 수 등)
+- **comments**: 게시글 댓글 (좋아요 포함)
+- **polls / poll_responses**: 투표형 게시글과 사용자 응답 관리
+- **likes**: 게시글/댓글 좋아요 내역
+- **attachments**: 게시글 첨부파일 메타데이터
 
 ## 🎨 UI/UX 가이드라인
 
-* **컬러 테마**: 녹색 계열 (`green-50 ~ emerald-100`)
-* **다크 모드** 지원
-* **반응형** 웹 (모바일/태블릿/PC)
-* **아이콘/이모지 활용**으로 직관적인 UX
-* **부드러운 애니메이션**과 인터랙션
+- **컬러 테마**: 녹색 계열 (`green-50 ~ emerald-100`)
+- **다크 모드** 지원
+- **반응형** 웹 (모바일/태블릿/PC)
+- **아이콘/이모지 활용**으로 직관적인 UX
+- **부드러운 애니메이션**과 인터랙션
 
 ## 📝 API 구조
 
 ### Auth
 
-* `POST /api/v1/members/signup` – 회원가입
-* `POST /api/v1/members/login` – 로그인 (JWT 발급)
-* `POST /api/v1/members/logout` – 로그아웃
-* `POST /api/v1/members/refresh` – 토큰 재발급
+- `POST /api/v1/members/signup` – 회원가입
+- `POST /api/v1/members/login` – 로그인 (JWT 발급)
+- `POST /api/v1/members/logout` – 로그아웃
+- `POST /api/v1/members/refresh` – 토큰 재발급
 
 ### Regions
 
-* `GET /api/v1/regions` – 지역 목록 조회
-* `GET /api/v1/regions/{regionId}/stats` – 특정 지역 통계
-* `GET /api/v1/regions/{regionId}/top-stocks` – 지역 인기 주식 상위 3개
+- `GET /api/v1/regions` – 지역 목록 조회
+- `GET /api/v1/regions/{regionId}/stats` – 특정 지역 통계
+- `GET /api/v1/regions/{regionId}/top-stocks` – 지역 인기 주식 상위 3개
 
 ### Stocks
 
-* `GET /api/v1/stocks/{symbol}` – 종목 상세 조회
-* `GET /api/v1/stocks/ticker` – 주식 티커 데이터
-* `GET /api/v1/stocks/search?query={키워드}` – 종목 검색
+- `GET /api/v1/stocks/{symbol}` – 종목 상세 조회
+- `GET /api/v1/stocks/ticker` – 주식 티커 데이터
+- `GET /api/v1/stocks/search?query={키워드}` – 종목 검색
 
 ### Community
 
-* 게시글 작성/조회/수정/삭제, 좋아요
-* 댓글 작성/조회/삭제, 좋아요
-* 인기 게시글 조회
+- 게시글 작성/조회/수정/삭제, 좋아요
+- 댓글 작성/조회/삭제, 좋아요
+- 인기 게시글 조회
 
 ### WebSocket
 
-* `ws://<server>/ws/chat/region?regionId={id}&token={JWT}`
+- `ws://<server>/ws/chat/region?regionId={id}&token={JWT}`
   → 지역 채팅방 연결
 
 ## 🔒 환경 변수
 
-* `KAKAO_MAP_API_KEY`: 카카오 지도 API 키
-* `KAKAO_REST_API_KEY`: 카카오 REST API 키
-* `DB_URL`: 데이터베이스 URL
-* `DB_USERNAME`: DB 사용자명
-* `DB_PASSWORD`: DB 비밀번호
-* `JWT_SECRET`: JWT 비밀키
+- `KAKAO_MAP_API_KEY`: 카카오 지도 API 키
+- `KAKAO_REST_API_KEY`: 카카오 REST API 키
+- `DB_URL`: 데이터베이스 URL
+- `DB_USERNAME`: DB 사용자명
+- `DB_PASSWORD`: DB 비밀번호
+- `JWT_SECRET`: JWT 비밀키
 
 ## 🔮 향후 추가 예정 기능
 
-* 투표 기반 주가 예측
-* 관심 종목/지역 알림
-* 실시간 차트 대시보드
-* 모바일 앱 (PWA)
-* CI/CD, Docker 기반 배포
-* 보안 강화 및 HTTPS 적용
+- 투표 기반 주가 예측
+- 관심 종목/지역 알림
+- 실시간 차트 대시보드
+- 모바일 앱 (PWA)
+- CI/CD, Docker 기반 배포
+- 보안 강화 및 HTTPS 적용
 
 ## 📄 라이선스
 


### PR DESCRIPTION
## 주요 변경사항

### Backend
- **MongoDB 연동**: 채팅 메시지 저장 및 조회 기능 구현
  - RegionChatMessage 엔티티 추가
  - RegionChatService 및 Repository 구현
  - 채팅 히스토리 조회 API 추가 (최근 메시지, 메시지 개수)

- **금융 캘린더 API**: ECOS API 통합
  - EcosApiService 및 FinancialCalendarService 구현
  - 주간 경제 지표 캘린더 제공
  - 캘린더 데이터 캐싱 처리

- **WebSocket 핸들러 개선**
  - 채팅 메시지를 MongoDB에 비동기 저장
  - 이미지 및 포트폴리오 데이터 처리

### Frontend
- **채팅 히스토리 로딩**: 컴포넌트 마운트 시 이전 채팅 메시지 불러오기
- **금융 캘린더 UI**: 
  - financial-calendar.tsx 컴포넌트 추가
  - korea-indicator-card.tsx 컴포넌트 추가
  - 주간 경제 지표 시각화

### Infrastructure
- **Docker 설정**: MongoDB 서비스 추가
- **환경 변수**: Redis 및 MongoDB 설정 추가
- **MongoDB 초기화 스크립트**: 사용자 및 컬렉션 생성

### Documentation
- README.md 업데이트 (API 구조, 데이터베이스 구조, 글로벌 서비스 섹션 추가)